### PR TITLE
optional 사용 위해서는 nebula.optional-base 필요 한게 아닌가요?

### DIFF
--- a/plugin/Assistant-Properties.md
+++ b/plugin/Assistant-Properties.md
@@ -56,6 +56,20 @@ Properties 속성값과 바인딩 될 객체입니다.
 
 ### gradle
 ```
+buildscript {
+  repositories {
+    jcenter()
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
+  }
+}
+
+apply plugin: 'nebula.optional-base'
+
+...
+
 dependencies {
     optional "org.springframework.boot:spring-boot-configuration-processor"
 }


### PR DESCRIPTION
gradle 4.10.3 으로 테스트 할때 그냥 사용이 안되서요 혹시 제가 잘못 알고 있는건가요?
다른 사람들도 착각 할거 같아서 할줄 적어 봅니다.

https://github.com/cheese10yun/spring-guide 보면서 많은 생각을 하게 되내요 감사합니다.